### PR TITLE
[fix] reflected XSS

### DIFF
--- a/resources/error.gtl
+++ b/resources/error.gtl
@@ -10,7 +10,7 @@
 [[include:menubar.gtl]][[/include:menubar.gtl]]
 
 [[if:_message]]
-<div class='message'>{{_message}}</div>
+<div class='message'>{{_message:text}}</div>
 [[/if:_message]]
 
 </body>


### PR DESCRIPTION
Rather than sanitizing a user's input by forbidding certain characters (prone to accidentally blocking needed characters), it is better practice to escape a user's input, i.e. to convert its characters into HTML entities e.g. "<" into "&lt;"

This is done here telling the error file to escape user input with the ":text" modifier.