### PR TITLE
[fix] admin access to quit- and reset-urls

### DIFF
--- a/gruyere.py
+++ b/gruyere.py
@@ -236,6 +236,8 @@ class GruyereRequestHandler(BaseHTTPRequestHandler):
   # Urls that can only be accessed by administrators.
   _PROTECTED_URLS = [
       '/quitserver',
+      '/QUITSERVER',
+      '/RESET',
       '/reset'
   ]
 

--- a/gruyere.py
+++ b/gruyere.py
@@ -235,7 +235,7 @@ class GruyereRequestHandler(BaseHTTPRequestHandler):
 
   # Urls that can only be accessed by administrators.
   _PROTECTED_URLS = [
-      '/quit',
+      '/quitserver',
       '/reset'
   ]
 


### PR DESCRIPTION
Adds /quitserver to the protected urls that only an admin can access, as well as capitalizations /QUITSERVER and /RESET, as html is not case-sensitive and the protections could otherwise be bypassed by capitalizing the commands in the url.