### PR TITLE
[fix] path traversal

### DIFF
--- a/gruyere.py
+++ b/gruyere.py
@@ -59,6 +59,7 @@ COOKIE_UID = 'uid'
 COOKIE_ADMIN = 'is_admin'
 COOKIE_AUTHOR = 'is_author'
 
+whitelisted_resources = ["/" + n for n in os.listdir(RESOURCE_PATH)] + ["/data.py"]
 
 # Set to True to cause the server to exit after processing the current url.
 quit_server = False
@@ -510,6 +511,10 @@ class GruyereRequestHandler(BaseHTTPRequestHandler):
       specials: Other special values for this request.
       params: Cgi parameters.
     """
+    
+    if filename not in whitelisted_resources:
+      return
+    
     content_type = None
     if filename.endswith('.gtl'):
       self._SendTemplateResponse(filename, specials, params)


### PR DESCRIPTION
Path traversal was possible because there were no checks on which files could be legitimately served. This fix crawls the resources folder at runtime (and the _data.py_ file that gruyere uses for the background image and its pre-existing dummy users) and only allows those resources to be served to the user.
This prevents being able to access files from outside the resource folder by simply appending _/../filename_ to the url. 